### PR TITLE
Remove fields dropped from shopify api 2024-01

### DIFF
--- a/lib/shopify/resources/customer.ex
+++ b/lib/shopify/resources/customer.ex
@@ -21,12 +21,12 @@ defmodule Shopify.Customer do
   }
 
   defstruct [
-    :accepts_marketing,
     :addresses,
     :created_at,
     :currency,
     :default_address,
     :email,
+    :email_marketing_consent,
     :phone,
     :first_name,
     :id,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Shopify.Mixfile do
   use Mix.Project
 
-  @version "0.7.4"
+  @version "0.8.0"
 
   def project do
     [

--- a/test/customer_saved_search_test.exs
+++ b/test/customer_saved_search_test.exs
@@ -63,7 +63,7 @@ defmodule Shopify.CustomerSavedSearchTest do
 
   test "client can request to update an customer_saved_search" do
     assert {:ok, response} = Shopify.session() |> CustomerSavedSearch.find(1)
-    assert "Accepts Marketing" == response.data.name
+    assert "Has one order" == response.data.name
     update = %{response.data | name: "Update"}
     assert {:ok, response} = Shopify.session() |> CustomerSavedSearch.update(1, update)
     assert "Update" == response.data.name

--- a/test/fixtures/checkouts.json
+++ b/test/fixtures/checkouts.json
@@ -150,7 +150,11 @@
             "customer": {
                 "id": 517303009322,
                 "email": "bob.mctest@test.com",
-                "accepts_marketing": false,
+                "email_marketing_consent": {
+                  "state": "subscribed",
+                  "opt_in_level": "confirmed_opt_in",
+                  "consent_updated_at": "2022-04-01T11:22:06-04:00"
+                },
                 "created_at": "2018-03-19T23:08:01-04:00",
                 "updated_at": "2018-03-19T23:08:01-04:00",
                 "first_name": "Bob",

--- a/test/fixtures/customer_saved_searches.json
+++ b/test/fixtures/customer_saved_searches.json
@@ -2,10 +2,10 @@
   "customer_saved_searches": [
     {
       "id": 789629109,
-      "name": "Accepts Marketing",
+      "name": "Has one order",
       "created_at": "2018-02-19T16:23:25-05:00",
       "updated_at": "2018-02-19T16:23:25-05:00",
-      "query": "accepts_marketing:1"
+      "query": "orders_count:1"
     },
     {
       "id": 20610973,

--- a/test/fixtures/customer_saved_searches/1.json
+++ b/test/fixtures/customer_saved_searches/1.json
@@ -1,9 +1,9 @@
 {
   "customer_saved_search": {
     "id": 1,
-    "name": "Accepts Marketing",
+    "name": "Has one order",
     "created_at": "2018-02-19T16:23:25-05:00",
     "updated_at": "2018-02-19T16:23:25-05:00",
-    "query": "accepts_marketing:1"
+    "query": "orders_count:1"
   }
 }

--- a/test/fixtures/customer_saved_searches/1/customers.json
+++ b/test/fixtures/customer_saved_searches/1/customers.json
@@ -3,7 +3,11 @@
     {
       "id": 207119551,
       "email": "bob.norman@hostmail.com",
-      "accepts_marketing": true,
+      "email_marketing_consent": {
+        "state": "subscribed",
+        "opt_in_level": "confirmed_opt_in",
+        "consent_updated_at": "2022-04-01T11:22:06-04:00"
+      },
       "created_at": "2018-02-26T16:23:25-05:00",
       "updated_at": "2018-02-26T16:28:24-05:00",
       "first_name": "Bob",

--- a/test/fixtures/customers.json
+++ b/test/fixtures/customers.json
@@ -3,7 +3,11 @@
     {
       "id": 207119551,
       "email": "bob.norman@hostmail.com",
-      "accepts_marketing": false,
+      "email_marketing_consent": {
+        "marketing_state": "not_subscribed",
+        "opt_in_level": "confirmed_opt_in",
+        "consent_updated_at": "2022-04-01T11:22:06-04:00"
+      },
       "created_at": "2018-05-07T15:33:38-04:00",
       "updated_at": "2018-05-07T15:33:38-04:00",
       "first_name": "Bob",
@@ -63,7 +67,11 @@
     {
       "id": 1073339461,
       "email": "steve.lastnameson@example.com",
-      "accepts_marketing": false,
+      "email_marketing_consent": {
+        "marketing_state": "not_subscribed",
+        "opt_in_level": "confirmed_opt_in",
+        "consent_updated_at": "2022-04-01T11:22:06-04:00"
+      },
       "created_at": "2018-05-07T15:51:45-04:00",
       "updated_at": "2018-05-07T15:51:45-04:00",
       "first_name": "Steve",

--- a/test/fixtures/customers/1.json
+++ b/test/fixtures/customers/1.json
@@ -2,7 +2,11 @@
   "customer": {
     "id": 207119551,
     "email": "bob.norman@hostmail.com",
-    "accepts_marketing": false,
+    "email_marketing_consent": {
+      "marketing_state": "not_subscribed",
+      "opt_in_level": "confirmed_opt_in",
+      "consent_updated_at": "2022-04-01T11:22:06-04:00"
+    },
     "created_at": "2018-05-07T15:33:38-04:00",
     "updated_at": "2018-05-07T15:33:38-04:00",
     "first_name": "Bob",

--- a/test/fixtures/customers/1/orders.json
+++ b/test/fixtures/customers/1/orders.json
@@ -434,7 +434,11 @@
       "customer": {
         "id": 207119551,
         "email": "bob.norman@hostmail.com",
-        "accepts_marketing": false,
+        "email_marketing_consent": {
+          "marketing_state": "not_subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "created_at": "2018-05-07T15:33:38-04:00",
         "updated_at": "2018-05-07T15:33:38-04:00",
         "first_name": "Bob",

--- a/test/fixtures/draft_orders.json
+++ b/test/fixtures/draft_orders.json
@@ -82,7 +82,11 @@
       "customer": {
         "id": 207119551,
         "email": "bob.norman@hostmail.com",
-        "accepts_marketing": false,
+        "email_marketing_consent": {
+          "state": "subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "created_at": "2018-03-21T11:32:36-04:00",
         "updated_at": "2018-03-21T11:32:36-04:00",
         "first_name": "Bob",
@@ -246,7 +250,11 @@
       "customer": {
         "id": 207119551,
         "email": "bob.norman@hostmail.com",
-        "accepts_marketing": false,
+        "email_marketing_consent": {
+          "state": "subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "created_at": "2018-03-21T11:32:36-04:00",
         "updated_at": "2018-03-21T11:32:36-04:00",
         "first_name": "Bob",
@@ -370,7 +378,11 @@
       "customer": {
         "id": 207119551,
         "email": "bob.norman@hostmail.com",
-        "accepts_marketing": false,
+        "email_marketing_consent": {
+          "state": "subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "created_at": "2018-03-21T11:32:36-04:00",
         "updated_at": "2018-03-21T11:32:36-04:00",
         "first_name": "Bob",
@@ -500,7 +512,11 @@
       "customer": {
         "id": 207119551,
         "email": "bob.norman@hostmail.com",
-        "accepts_marketing": false,
+        "email_marketing_consent": {
+          "state": "subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "created_at": "2018-03-21T11:32:36-04:00",
         "updated_at": "2018-03-21T11:32:36-04:00",
         "first_name": "Bob",

--- a/test/fixtures/draft_orders/1.json
+++ b/test/fixtures/draft_orders/1.json
@@ -92,7 +92,11 @@
     "customer": {
       "id": 207119551,
       "email": "bob.norman@hostmail.com",
-      "accepts_marketing": false,
+      "email_marketing_consent": {
+        "state": "subscribed",
+        "opt_in_level": "confirmed_opt_in",
+        "consent_updated_at": "2022-04-01T11:22:06-04:00"
+      },
       "created_at": "2018-03-21T11:32:36-04:00",
       "updated_at": "2018-03-21T11:32:36-04:00",
       "first_name": "Bob",

--- a/test/fixtures/orders.json
+++ b/test/fixtures/orders.json
@@ -259,9 +259,13 @@
         "user_agent": null
       },
       "customer": {
-        "accepts_marketing": false,
         "created_at": "2014-03-07T16:14:08-05:00",
         "email": "bob.norman@hostmail.com",
+        "email_marketing_consent": {
+          "state": "subscribed",
+          "opt_in_level": "confirmed_opt_in",
+          "consent_updated_at": "2022-04-01T11:22:06-04:00"
+        },
         "first_name": "Bob",
         "id": 207119551,
         "last_name": "Norman",

--- a/test/fixtures/orders/1.json
+++ b/test/fixtures/orders/1.json
@@ -429,7 +429,11 @@
     "customer": {
       "id": 207119551,
       "email": "bob.norman@hostmail.com",
-      "accepts_marketing": false,
+      "email_marketing_consent": {
+        "state": "subscribed",
+        "opt_in_level": "confirmed_opt_in",
+        "consent_updated_at": "2022-04-01T11:22:06-04:00"
+      },
       "created_at": "2017-01-09T15:09:12-05:00",
       "updated_at": "2017-01-09T15:09:12-05:00",
       "first_name": "Bob",

--- a/test/webhook_test.exs
+++ b/test/webhook_test.exs
@@ -64,13 +64,13 @@ defmodule Shopify.WebhookTest do
 
   test "authorized webhooks will return true" do
     body = ~s({"foo": "bar"})
-    hmac = :crypto.hmac(:sha256, Shopify.Config.get(:client_secret), body) |> Base.encode64()
+    hmac = :crypto.mac(:hmac, :sha256, Shopify.Config.get(:client_secret), body) |> Base.encode64()
     assert Webhook.authenticate(hmac, body)
   end
 
   test "unauthorized webhooks will return false" do
     body = ~s({"foo": "bar"})
-    hmac = :crypto.hmac(:sha256, Shopify.Config.get(:client_secret), body) |> Base.encode64()
+    hmac = :crypto.mac(:hmac, :sha256, Shopify.Config.get(:client_secret), body) |> Base.encode64()
     refute Webhook.authenticate(hmac, ~s({"foo": "baz"}))
   end
 end


### PR DESCRIPTION
shopify api version 2024-01 removes the previously deprecated accepts_marketing field on the customer object, hence in order to be compatible with that version of shopify api I'm removing this field and adding the email_marketing_consent field that replaces it